### PR TITLE
Correct dump of cluster resources to be single item per file

### DIFF
--- a/kube-dump
+++ b/kube-dump
@@ -446,17 +446,17 @@ if [[ "$mode" =~ ^(dump|all|dump-cluster|cls)$ ]]; then
       msg-start "$resource" "$name"
 
       # Save resource to file
-      kubectl get --output='json' "$resource" "${k_args[@]}" | \
+      kubectl get --output='json' "$resource" "$name" "${k_args[@]}" | \
         jq --exit-status --compact-output --monochrome-output \
           --raw-output --sort-keys 2>/dev/null \
         'del(
-          .items[].metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",
-          .items[].metadata.annotations."control-plane.alpha.kubernetes.io/leader",
-          .items[].metadata.uid,
-          .items[].metadata.selfLink,
-          .items[].metadata.resourceVersion,
-          .items[].metadata.creationTimestamp,
-          .items[].metadata.generation
+          .metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",
+          .metadata.annotations."control-plane.alpha.kubernetes.io/leader",
+          .metadata.uid,
+          .metadata.selfLink,
+          .metadata.resourceVersion,
+          .metadata.creationTimestamp,
+          .metadata.generation
         )' | \
       yq eval --prettyPrint --no-colors --exit-status - \
         >"$destination_dir/cluster/${name//:/-}_$resource".yaml 2>/dev/null && \


### PR DESCRIPTION
Currently when I run `kube-dump cls` it is creating a file for each resource, but these files would be a list of every resource of that kind due to the kubectl get cmd lacking the resource name when it fetches the manifest. In the case of `ClusterRole` resources, each file was ending up at nearly 5k lines long since every one of them contained all For example, `cluster/default_Namespace.yaml` would be written like this:

```
apiVersion: v1
items:
  - apiVersion: v1
    kind: Namespace
    metadata:
      name: default
    spec:
      finalizers:
        - kubernetes
    status:
      phase: Active
  - apiVersion: v1
    kind: Namespace
    metadata:
      name: kube-public
    spec:
      finalizers:
        - kubernetes
    status:
      phase: Active
  - apiVersion: v1
    kind: Namespace
    metadata:
      name: kube-system
    spec:
      finalizers:
        - kubernetes
    status:
      phase: Active

// etc
```

What this PR accomplishes is correctly writing a single item per file, so this file is instead written as it should be (with similar single-item files for `kube-public` and `kube-system` etc):

```
apiVersion: v1
kind: Namespace
metadata:
  name: default
spec:
  finalizers:
    - kubernetes
status:
  phase: Active
```
