### PR TITLE
Delete always changing annotations from HPAs

### DIFF
--- a/kube-dump
+++ b/kube-dump
@@ -397,6 +397,8 @@ if [[ "$mode" =~ ^(dump|all|dump-namespaces|ns)$ ]]; then
         jq --exit-status --compact-output --monochrome-output \
           --raw-output --sort-keys 2>/dev/null \
           'del(
+            .metadata.annotations."autoscaling.alpha.kubernetes.io/conditions",
+            .metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics",
             .metadata.annotations."control-plane.alpha.kubernetes.io/leader",
             .metadata.annotations."deployment.kubernetes.io/revision",
             .metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",


### PR DESCRIPTION
Autoscalers use annotations which frequently change to store status and scaling information, and these should be removed from the dumped resources to avoid constant deltas such as the following from one dump to the next:

```diff
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:
-    autoscaling.alpha.kubernetes.io/conditions: '[{"type":"AbleToScale","status":"True","lastTransitionTime":"2020-08-20T16:24:39Z","reason":"ReadyForNewScale","message":"recommended size matches current size"},{"type":"ScalingActive","status":"True","lastTransitionTime":"2021-07-29T16:33:32Z","reason":"ValidMetricFound","message":"the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)"},{"type":"ScalingLimited","status":"True","lastTransitionTime":"2021-07-29T16:22:27Z","reason":"TooFewReplicas","message":"the desired replica count is less than the minimum replica count"}]'
-    autoscaling.alpha.kubernetes.io/current-metrics: '[{"type":"Resource","resource":{"name":"cpu","currentAverageUtilization":1,"currentAverageValue":"39m"}}]'
+    autoscaling.alpha.kubernetes.io/conditions: '[{"type":"AbleToScale","status":"True","lastTransitionTime":"2020-08-20T16:24:39Z","reason":"ScaleDownStabilized","message":"recent recommendations were higher than current one, applying the highest recent recommendation"},{"type":"ScalingActive","status":"True","lastTransitionTime":"2021-07-29T16:33:32Z","reason":"ValidMetricFound","message":"the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)"},{"type":"ScalingLimited","status":"True","lastTransitionTime":"2021-07-29T16:22:27Z","reason":"TooFewReplicas","message":"the desired replica count is less than the minimum replica count"}]'
+    autoscaling.alpha.kubernetes.io/current-metrics: '[{"type":"Resource","resource":{"name":"cpu","currentAverageUtilization":0,"currentAverageValue":"18m"}}]'
   labels:
     checksum/config: 8f8cf58cd811299382da59ff94e46720b010882208e42053efb4aa9503769a8
```