### PR TITLE
fixed the sed regex to match the hyphen in git_remote_url

### DIFF
--- a/kube-dump
+++ b/kube-dump
@@ -395,7 +395,7 @@ if [ "$git_push" == 'true' ] && [ ! -d "$destination_dir/.git/" ]; then
 
   if ! grep --quiet --extended-regexp 'https?:\/\/' <<< "$git_remote_url"; then
 
-    _remote_url=$(sed -r 's|.*@([A-Za-z0-9\-\.]+):.*|\1|' <<< "$git_remote_url")
+    _remote_url=$(sed -r 's|.*@([A-Za-z0-9\.-]+):.*|\1|' <<< "$git_remote_url")
     ! grep --quiet "^$_remote_url " ~/.ssh/known_hosts >/dev/null 2>&1 && \
       ssh-keyscan "$_remote_url" >> ~/.ssh/known_hosts 2>/dev/null
 


### PR DESCRIPTION
Apparently just escaping the dash in that regex isn't working and a quick google search suggested it needs to be placed in the beginning or the end of the group to distinguish it from being a range separator.

```
sed -r 's|.*@([A-Za-z0-9\-\.]+):.*|\1|' <<< git@gitea-ssh.homelab:devops/k3s.git
git@gitea-ssh.homelab:devops/k3s.git
```
vs
```
sed -r 's|.*@([A-Za-z0-9\.-]+):.*|\1|' <<< git@gitea-ssh.homelab:devops/k3s.git
gitea-ssh.homelab
```

The script was just silently failing until I fixed the regex.