### PR TITLE
require func is fail

### DIFF
--- a/kube-dump
+++ b/kube-dump
@@ -66,7 +66,7 @@ fail () {
 # Check command is exist
 require () {
   for command in "$@"; do
-    if ! [ -x "$(command -v "$command")" ]; then
+    if [ ! -x "$(command -v "$command")" ]; then
       fail "'$command' util not found, please install it first"
     fi
   done


### PR DESCRIPTION
# Check command is exist

I found require method to detect whether the command exists is invalid, take antisyntax problems
Here's the correct way to write it 
require () {
  for command in "$@"; do
    if [ ! -x "$(command -v "$command")" ]; then
      fail "'$command' util not found, please install it first"
    fi
  done
}