### PR TITLE
Exclude specific namespace resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,19 @@ All environment variables are described in the [`.env`](./.env) file,
 you can use them both for the container launch configuration and
 directly from the [`.env`](./.env) file, it is read automatically at startup.
 
-## Resources default's
+## Selecting resources
 
-All resources automatically discovered from the API if not pass as argument.
-
-* List of namespaces
-* List of default namespaced resources
-* List of default cluster wide resources
+Namespaces, namespaced resources and cluster wide resources
+may be specified as comma-separated list:
+```text
+  item1,item2,...
+```
+Also, specific namespaced resources may be excluded using '!' prefix,
+while special name "ALL" means all namespaced resources:
+```text
+  -r 'ALL,!events,!events.events.k8s.io'
+```
+If resources are not specified, they are automatically discovered from the API.
 
 ## Plans for further development 
 

--- a/kube-dump
+++ b/kube-dump
@@ -150,7 +150,7 @@ args=$(
   getopt \
     -l "namespaces:,namespaced-resources:,cluster-resources:" \
     -l "kube-config:,kube-context:,kube-cluster:,kube-insecure-tls" \
-    -l "help,silent,destination:,force-remove,detailed,output-by-type,flat" \
+    -l "help,silent,destination-dir:,force-remove,detailed,output-by-type,flat" \
     -l "git-commit,git-push,git-branch:,git-commit-user:,git-commit-email:" \
     -l "git-remote-name:,git-remote-url:" \
     -l "archivate,archive-rotate-days:,archive-type:" \

--- a/kube-dump
+++ b/kube-dump
@@ -317,7 +317,27 @@ if [ -z "${namespaced_resources:-$NAMESPACED_RESOURCES}" ]; then
     tr '\n' ' '
   )"
 else
-  namespaced_resources=${namespaced_resources:-$NAMESPACED_RESOURCES}
+  nr_in=${namespaced_resources:-$NAMESPACED_RESOURCES}
+  nr_out=''
+  for nr in ${nr_in//,/ }; do
+    if [[ "$nr" == ALL ]] ; then
+      nr_out="${nr_out} $(kubectl api-resources --namespaced=true --output=name \
+      "${k_args[@]}" | tr '\n' ' ')"
+    elif [[ "$nr" == \!* ]] ; then
+      # filter out $nr from list
+      del=${nr#!}
+      nr_out2=''
+      for nr2 in ${nr_out} ; do
+        if [[ "$nr2" != $del ]] ; then
+          nr_out2="${nr_out2} ${nr2}"
+        fi
+      done
+      nr_out="$nr_out2"
+    else
+      nr_out="${nr_out} ${nr}"
+    fi
+  done
+  namespaced_resources="${nr_out}"
 fi
 
 # Set cluster resources


### PR DESCRIPTION
Rationale: deployment tools like argocd clog up
its namespace with thousands of dynamic events,
which are unnecessary to dump.
Closes: #38
See Also: #25