### PR TITLE
Add container support for aws-cli and AWS EKS clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ LABEL maintainer="woozymasta@gmail.com"
 
 # hadolint ignore=DL3018
 RUN apk add --update --no-cache \
-    bash bind-tools jq yq openssh-client git tar xz gzip bzip2 curl coreutils grep && \
+    bash bind-tools jq yq openssh-client git tar xz gzip bzip2 curl coreutils grep python3 py3-pip && \
     curl -sLo /usr/bin/kubectl \
     "https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \
     chmod +x /usr/bin/kubectl
+
+RUN pip3 install awscli
 
 COPY ./kube-dump /kube-dump
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Optional dependencies:
   * `xz` - a lossless data compression file format based on the LZMA algorithm
   * `gzip` - single-file/stream lossless data compression utility
   * `bzip2` - compression program that uses the Burrows–Wheeler algorithm
+* `aws-cli` - support for access to Amazon EKS clusters
 
 ## Commands and flags
 

--- a/docs/container.md
+++ b/docs/container.md
@@ -13,6 +13,14 @@ docker run --tty --interactive --rm \
 
 Kube-dump is set as entrypoint, you only need to pass command and flags to container.
 
+When connecting to AWS EKS, add your credentials as a volume mount for aws-cli to authenticate:
+```shell
+docker run --tty --interactive --rm \
+  --volume $HOME/.kube:/.kube --volume $HOME/.aws:/root/.aws --volume $HOME/dump:/dump \
+  woozymasta/kube-dump:latest \
+  dump-namespaces -n dev,prod -d /dump --kube-config /.kube/config
+```
+
 For more convenience, you can create an alias for calling kube-dump from a container:
 
 ```shell


### PR DESCRIPTION
This PR adds support to dump AWS EKS clusters that require authentication via the aws-cli. 

Proposed changes:
* Installs the aws-cli inside of the container via python and pip
* Updates both README's to reflect support for AWS

Tested against 1.24.x and 1.26.x clusters in EKS.