### PR TITLE
Remove spec.clusterIPs to make Service compatible with different IP range

### DIFF
--- a/kube-dump
+++ b/kube-dump
@@ -362,6 +362,7 @@ namespaced_jq_filter=$(cat <<-END
     .metadata.selfLink,
     .metadata.uid,
     .spec.clusterIP,
+    .spec.clusterIPs,
     .spec.progressDeadlineSeconds,
     .spec.revisionHistoryLimit,
     .spec.template.metadata.annotations."kubectl.kubernetes.io/restartedAt",


### PR DESCRIPTION
Both `spec.ClusterIP` and `spec.ClusterIPs` should be cleaned up during dumping. This will help to avoid restoring a Service that has different networking range.